### PR TITLE
Replacing last case with the default statement

### DIFF
--- a/Day 2/Conditional Statements Switch.js
+++ b/Day 2/Conditional Statements Switch.js
@@ -16,9 +16,9 @@ function getLetter(s) {
                 letter = 'C';
                 break;
                 
-            case ('z' || 'n' || 'p' || 'q' || 'r' || 's' || 't' || 'v' || 'w' || 'x' || 'y' ):
+            default:
                 letter = 'D';
-                
+                break;
         }
     
     


### PR DESCRIPTION
If you pay close attention, then you can see that all letters are taken from the alphabet. All the letters that aren't included for A B C can't be simply added into default clause which will always return letter D.